### PR TITLE
Fixed the evaluation of can-load attribute to perform as documented.

### DIFF
--- a/src/infinite-scroll.js
+++ b/src/infinite-scroll.js
@@ -6,7 +6,7 @@ angular.module('infiniteScroll', [])
                 var e = element[0];
 
                 element.bind('scroll', function () {
-                    if (scope.canLoad && e.scrollTop + e.offsetHeight >= e.scrollHeight - offset) {
+                    if (scope.$eval(attrs.canLoad) && e.scrollTop + e.offsetHeight >= e.scrollHeight - offset) {
                         scope.$apply(attrs.infiniteScroll);
                     }
                 });


### PR DESCRIPTION
 It used to be hard-coded against the `scope.canLoad` boolean value, rather than the documented `can-load` attribute.
