### PR TITLE
Fixed minification failure by adding explicit declaration for dependency injection of $window parameter

### DIFF
--- a/src/infinite-scroll.js
+++ b/src/infinite-scroll.js
@@ -1,5 +1,5 @@
 angular.module('infiniteScroll', [])
-    .directive('infiniteScroll', function ($window) {
+    .directive('infiniteScroll', [ "$window", function ($window) {
         return {
             link:function (scope, element, attrs) {
                 var offset = parseInt(attrs.threshold) || 0;
@@ -11,5 +11,5 @@ angular.module('infiniteScroll', [])
                     }
                 });
             }
-        }
-    })
+        };
+    }]);


### PR DESCRIPTION
The lack of explicit declaration for dependency injection caused failure when building a minified version of an application that uses angular-infinite-scroll.

Added explicit declaration of $window parameter for dependency injection.
